### PR TITLE
Boundary BytesIO support in basemapper.py

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -26,9 +26,9 @@ import queue
 import re
 import sys
 import threading
+from io import BytesIO
 from pathlib import Path
 from typing import Union
-from io import BytesIO
 
 import geojson
 import mercantile
@@ -302,7 +302,7 @@ class BaseMapper(object):
 
         log.debug(f"Reading geojson file: {boundary}")
         poly = None
-        #If boundary given is BytesIO object
+        # If boundary given is BytesIO object
         if isinstance(boundary, BytesIO):
             poly = geojson.load(boundary)
         else:

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -22,9 +22,9 @@
 import argparse
 import concurrent.futures
 import logging
+import os
 import queue
 import re
-import os
 import sys
 import threading
 from io import BytesIO
@@ -560,11 +560,11 @@ def main():
         quit()
 
     if os.path.isfile(args.boundary):
-            with open(args.boundary, 'rb') as f:
-                boundary = BytesIO(f.read())
+        with open(args.boundary, "rb") as f:
+            boundary = BytesIO(f.read())
     else:
         log.info("Could not load boundary as file. Loading as string")
-        boundary = args.boundary # is bbox string        
+        boundary = args.boundary  # is bbox string
 
     create_basemap_file(
         verbose=args.verbose,

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -420,7 +420,7 @@ def create_basemap_file(
 
     Args:
         verbose (bool, optional): Enable verbose output if True.
-        boundary (str, optional): The boundary for the area you want.
+        boundary (str | None | BytesIO): The boundary for the area you want.
         tms (str, optional): Custom TMS URL.
         xy (bool, optional): Swap the X & Y coordinates when using a
             custom TMS if True.

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -559,9 +559,16 @@ def main():
         parser.print_help()
         quit()
 
+    boundary_bytesio = None
+    try:
+        with open(args.boundary, "rb") as f:
+            boundary_bytesio = BytesIO(f.read())
+    except FileNotFoundError:
+        log.error("Boundary file could not be loaded!")
+
     create_basemap_file(
         verbose=args.verbose,
-        boundary=args.boundary,
+        boundary=boundary_bytesio,
         tms=args.tms,
         xy=args.xy,
         outfile=args.outfile,

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -278,7 +278,7 @@ class BaseMapper(object):
         """Make a bounding box from a shapely geometry.
 
         Args:
-            boundary (str | BytesIO ): A BBOX string or (loaded) GeoJSON file of the AOI.
+            boundary (str | BytesIO ): A BBOX string or loaded GeoJSON file of the AOI.
                 The GeoJSON can contain multiple geometries.
 
         Returns:
@@ -306,8 +306,8 @@ class BaseMapper(object):
         if isinstance(boundary, BytesIO):
             poly = geojson.load(boundary)
         else:
-            with open(boundary, "r") as f:
-                poly = geojson.load(f)
+            raise ValueError("Only BBOX string or BytesIO-loaded GeoJSON file are allowed")
+
         if "features" in poly:
             geometry = shape(poly["features"][0]["geometry"])
         elif "geometry" in poly:
@@ -472,7 +472,7 @@ def create_basemap_file(
 
     # Make a bounding box from the boundary file
     if not boundary:
-        err = "You need to specify a boundary! (file or bbox)"
+        err = "You need to specify a boundary! (BytesIO object or bbox)"
         log.error(err)
         raise ValueError(err)
 
@@ -565,6 +565,7 @@ def main():
             boundary_bytesio = BytesIO(f.read())
     except FileNotFoundError:
         log.error("Boundary file could not be loaded!")
+        quit()
 
     create_basemap_file(
         verbose=args.verbose,

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -134,7 +134,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary (str | BytesIO ): A BBOX string or loaded GeoJSON file of the AOI.
+            boundary (str | BytesIO ): A BBOX string or (loaded) GeoJSON file of the AOI.
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
@@ -278,7 +278,7 @@ class BaseMapper(object):
         """Make a bounding box from a shapely geometry.
 
         Args:
-            boundary (str | BytesIO ): A BBOX string or loaded GeoJSON file of the AOI.
+            boundary (str | BytesIO ): A BBOX string or (loaded) GeoJSON file of the AOI.
                 The GeoJSON can contain multiple geometries.
 
         Returns:

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -134,7 +134,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary (str | BytesIO ): A BBOX string or (loaded) GeoJSON file of the AOI.
+            boundary (str | BytesIO ): A BBOX string or BytesIO-loaded GeoJSON file of the AOI.
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
@@ -278,7 +278,7 @@ class BaseMapper(object):
         """Make a bounding box from a shapely geometry.
 
         Args:
-            boundary (str | BytesIO ): A BBOX string or loaded GeoJSON file of the AOI.
+            boundary (str | BytesIO ): A BBOX string or BytesIO-loaded GeoJSON file of the AOI.
                 The GeoJSON can contain multiple geometries.
 
         Returns:
@@ -420,7 +420,7 @@ def create_basemap_file(
 
     Args:
         verbose (bool, optional): Enable verbose output if True.
-        boundary (str | None | BytesIO): The boundary for the area you want.
+        boundary (str | BytesIO | None): The boundary for the area you want.
         tms (str, optional): Custom TMS URL.
         xy (bool, optional): Swap the X & Y coordinates when using a
             custom TMS if True.

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -23,6 +23,9 @@ import logging
 import os
 import shutil
 
+from io import BytesIO
+from osm_fieldwork.basemapper import create_basemap_file
+
 from osm_fieldwork.basemapper import BaseMapper
 from osm_fieldwork.sqlite import DataFile
 
@@ -65,6 +68,21 @@ def test_create():
 
     assert hits == 2
 
+def test_bytesio_boundary():
+    """Test creating a basemap file using BytesIO boundary object."""
+    boundary_bytesio = None
+    with open(boundary, "rb") as f:
+        boundary_bytesio = BytesIO(f.read())
+
+    create_basemap_file(
+        verbose=True,
+        boundary=boundary_bytesio,
+        outfile="outreachy.mbtiles",
+        zooms="12-15",
+        source="esri",
+    )
+
 
 if __name__ == "__main__":
     test_create()
+    test_bytesio_boundary()

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -47,29 +47,15 @@ bbox_string = "-105.508741, 39.915714, -105.499229, 39.920574" #gotten from Roll
 #    geometry = shape(poly)
 
 
-def test_create_with_boundary_path():
-    """Test that Basemapper object initializes with boundary path."""
-    hits = 0
-    basemap = BaseMapper(boundary, base, "topo", False)
-    tiles = list()
-    for level in [8, 9, 10, 11, 12]:
-        basemap.getTiles(level)
-        tiles += basemap.tiles
-
-    if len(tiles) == 5:
-        hits += 1
-
-    if tiles[0].x == 52 and tiles[1].y == 193 and tiles[2].x == 211:
-        hits += 1
-
-    outf = DataFile(outfile, basemap.getFormat())
-    outf.writeTiles(tiles, base)
-
-    os.remove(outfile)
-    shutil.rmtree(base)
-
-    assert hits == 2
-
+def test_fails_with_boundary_path():
+    """Test that Basemapper object fails with boundary path initialization."""
+    res = False
+    try:
+        _ = BaseMapper(boundary, base, "topo", False)
+    except ValueError:
+         res = True
+    
+    assert res == True
 
 def test_create_with_boundary_bytesio():
     """Test creating a basemap file using BytesIO boundary object."""

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -47,16 +47,6 @@ bbox_string = "-105.508741, 39.915714, -105.499229, 39.920574" #gotten from Roll
 #    geometry = shape(poly)
 
 
-def test_fails_with_boundary_path():
-    """Test that Basemapper object fails with boundary path initialization."""
-    res = False
-    try:
-        _ = BaseMapper(boundary, base, "topo", False)
-    except ValueError:
-         res = True
-    
-    assert res == True
-
 def test_create_with_boundary_bytesio():
     """Test creating a basemap file using BytesIO boundary object."""
     boundary_bytesio = None
@@ -86,21 +76,6 @@ def test_create_with_boundary_bytesio():
     assert hits == 2
 
 
-def test_create_basemap_file_with_bytesio():
-    """Test the create_basemap_file function using a BytesIO boundary object."""
-    boundary_bytesio = None
-    with open(boundary, "rb") as f:
-        boundary_bytesio = BytesIO(f.read())
-
-    create_basemap_file(
-        verbose=True,
-        boundary=boundary_bytesio,
-        outfile="outreachy.mbtiles",
-        zooms="12-15",
-        source="esri",
-    )
-
-
 def test_create_with_bbox_string():
     """Create a basemapper object using a bbox string"""
     hits = 0
@@ -125,8 +100,53 @@ def test_create_with_bbox_string():
     assert hits == 2
 
 
+def test_create_basemap_file_with_bytesio():
+    """test the create_basemap_file function using a bytesio boundary object."""
+    boundary_bytesio = None
+    with open(boundary, "rb") as f:
+        boundary_bytesio = BytesIO(f.read())
+
+    create_basemap_file(
+        verbose=True,
+        boundary=boundary_bytesio,
+        outfile=outfile,
+        zooms="12-15",
+        source="esri",
+    )
+
+
+def test_create_basemap_file_with_bbox_string():
+    """test the create_basemap_file function using a bbox string."""
+
+    create_basemap_file(
+        verbose=True,
+        boundary=bbox_string,
+        outfile=outfile,
+        zooms="12-15",
+        source="esri",
+    )
+
+
+def test_fails_with_boundary_path():
+    """Test that create_basemap_file object fails with boundary path initialization."""
+    res = False
+    try:
+        create_basemap_file(
+            verbose=True,
+            boundary=boundary,
+            outfile=outfile,
+            zooms="12-15",
+            source="esri",
+        )
+    except Exception as e: 
+         res = True
+    
+    assert res
+
 if __name__ == "__main__":
-    test_fails_with_boundary_path()
-    test_create_basemap_file_with_bytesio()
     test_create_with_boundary_bytesio()
     test_create_with_bbox_string()
+    test_create_basemap_file_with_bytesio()
+    test_create_basemap_file_with_bbox_string()
+
+    test_fails_with_boundary_path()

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -22,11 +22,9 @@
 import logging
 import os
 import shutil
-
 from io import BytesIO
-from osm_fieldwork.basemapper import create_basemap_file
 
-from osm_fieldwork.basemapper import BaseMapper
+from osm_fieldwork.basemapper import BaseMapper, create_basemap_file
 from osm_fieldwork.sqlite import DataFile
 
 log = logging.getLogger(__name__)
@@ -36,7 +34,7 @@ boundary = f"{rootdir}/testdata/Rollinsville.geojson"
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
 base = "./tiles"
 
-bbox_string = "-105.508741, 39.915714, -105.499229, 39.920574" #gotten from Rollinsville.gejson
+bbox_string = "-105.508741, 39.915714, -105.499229, 39.920574"  # gotten from Rollinsville.gejson
 # boundary = open(infile, "r")
 # poly = geojson.load(boundary)
 # if "features" in poly:
@@ -101,7 +99,7 @@ def test_create_with_bbox_string():
 
 
 def test_create_basemap_file_with_bytesio():
-    """test the create_basemap_file function using a bytesio boundary object."""
+    """Test the create_basemap_file function using a bytesio boundary object."""
     boundary_bytesio = None
     with open(boundary, "rb") as f:
         boundary_bytesio = BytesIO(f.read())
@@ -116,8 +114,7 @@ def test_create_basemap_file_with_bytesio():
 
 
 def test_create_basemap_file_with_bbox_string():
-    """test the create_basemap_file function using a bbox string."""
-
+    """Test the create_basemap_file function using a bbox string."""
     create_basemap_file(
         verbose=True,
         boundary=bbox_string,
@@ -138,15 +135,15 @@ def test_fails_with_boundary_path():
             zooms="12-15",
             source="esri",
         )
-    except Exception as e: 
-         res = True
-    
+    except Exception:
+        res = True
+
     assert res
+
 
 if __name__ == "__main__":
     test_create_with_boundary_bytesio()
     test_create_with_bbox_string()
     test_create_basemap_file_with_bytesio()
     test_create_basemap_file_with_bbox_string()
-
     test_fails_with_boundary_path()

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -48,7 +48,7 @@ bbox_string = "-105.508741, 39.915714, -105.499229, 39.920574" #gotten from Roll
 
 
 def test_create_with_boundary_path():
-    """See if the file got loaded."""
+    """Test that Basemapper object initializes with boundary path."""
     hits = 0
     basemap = BaseMapper(boundary, base, "topo", False)
     tiles = list()
@@ -79,8 +79,6 @@ def test_create_with_boundary_bytesio():
 
     hits = 0
     basemap = BaseMapper(boundary_bytesio, base, "topo", False)
-    with open(f"{rootdir}/testdata/temp_bbox_str", "w") as f:
-        f.write(str(basemap.bbox))
 
     tiles = list()
     for level in [8, 9, 10, 11, 12]:
@@ -102,8 +100,8 @@ def test_create_with_boundary_bytesio():
     assert hits == 2
 
 
-def test_create_basemap_file():
-    """Test the create_basemap_file function"""
+def test_create_basemap_file_with_bytesio():
+    """Test the create_basemap_file function using a BytesIO boundary object."""
     boundary_bytesio = None
     with open(boundary, "rb") as f:
         boundary_bytesio = BytesIO(f.read())
@@ -143,6 +141,6 @@ def test_create_with_bbox_string():
 
 if __name__ == "__main__":
     test_create_with_boundary_path()
-    test_create_basemap_file()
+    test_create_basemap_file_with_bytesio()
     test_create_with_boundary_bytesio()
     test_create_with_bbox_string()

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -126,7 +126,7 @@ def test_create_with_bbox_string():
 
 
 if __name__ == "__main__":
-    test_create_with_boundary_path()
+    test_fails_with_boundary_path()
     test_create_basemap_file_with_bytesio()
     test_create_with_boundary_bytesio()
     test_create_with_bbox_string()


### PR DESCRIPTION
## What does this PR do?

- `create_basemap_file` and `BaseMapper` now only work with either a BytesIO-loaded geojson file, or a bbox string.

- Support for loading the geojson file into BytesIO has been moved to the `main` function of `basemapper.py`.   

- Tests for the new basemapper.py file are written covering:
    - creating a BaseMapper object using a boundary param that is either:
        - a BytesIO object
        - a bbox string

    - using the `create_basemap_file` function with:
        - a BytesIO object
        - a bbox string
        - a boundary path (raises an Exception)      

